### PR TITLE
Make properties of the PersonalDataExportDownloaded event public

### DIFF
--- a/src/Events/PersonalDataExportDownloaded.php
+++ b/src/Events/PersonalDataExportDownloaded.php
@@ -7,10 +7,10 @@ use Spatie\PersonalDataExport\ExportsPersonalData;
 class PersonalDataExportDownloaded
 {
     /** @var string */
-    protected $zipFilename;
+    public $zipFilename;
 
     /** @var \Spatie\PersonalDataExport\ExportsPersonalData|null */
-    protected $user;
+    public $user;
 
     public function __construct(string $zipFilename, ?ExportsPersonalData $user)
     {


### PR DESCRIPTION
Since these properties were protected, there was no way of accessing it from event listeners. This PR makes them public.