### PR TITLE
Missing starting slash on namespace

### DIFF
--- a/src/PersonalDataExportServiceProvider.php
+++ b/src/PersonalDataExportServiceProvider.php
@@ -23,7 +23,7 @@ class PersonalDataExportServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'personal-data-export');
 
         Route::macro('personalDataExports', function (string $url) {
-            Route::get("$url/{zipFilename}", 'Spatie\PersonalDataExport\Http\Controllers\PersonalDataExportController@export')
+            Route::get("$url/{zipFilename}", '\Spatie\PersonalDataExport\Http\Controllers\PersonalDataExportController@export')
                 ->name('personal-data-exports');
         });
 


### PR DESCRIPTION
Changes in the commit https://github.com/spatie/laravel-personal-data-export/pull/16/commits/455ed1132f927e49073148787b11e58705a479ca from PR https://github.com/spatie/laravel-personal-data-export/pull/16 were creating a ` App\Http\Controllers\Spatie\PersonalDataExport\Http\Controllers\PersonalDataExportController does not exist` error.
This adds the missing starting slash and resolves things.
I'll have a look at the tests and be sure its covered.