### PR TITLE
Enable fluent setter by returning class on adding resource

### DIFF
--- a/src/PersonalDataSelection.php
+++ b/src/PersonalDataSelection.php
@@ -38,6 +38,8 @@ class PersonalDataSelection
     /**
      * @param string $nameInDownload
      * @param array|string $content
+     *
+     * @return \Spatie\PersonalDataExport\PersonalDataSelection
      */
     public function add(string $nameInDownload, $content)
     {
@@ -52,6 +54,8 @@ class PersonalDataSelection
         $this->files[] = $path;
 
         file_put_contents($path, $content);
+
+        return $this;
     }
 
     public function addFile(string $pathToFile, string $diskName = null)


### PR DESCRIPTION
Small fix to enable fluent setters like in the readme. `->add()` didn't return anything, so follow-up calls didn't either.

```php
public function selectPersonalData(PersonalDataSelection $personalDataSelection) {
    $personalDataSelection
        ->add('user.json', ['name' => $this->name, 'email' => $this->email])
        ->addFile(storage_path("avatars/{$this->id}.jpg")
        ->addFile('other-user-data.xml', 's3'));
}
```