### PR TITLE
Fix class name type hint in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The `selectPersonalData` is used to determine the content of the personal downlo
 ```php
 // in your user model
 
-public function selectPersonalData(PersonalData $personalData): void {
+public function selectPersonalData(PersonalDataSelection $personalData): void {
     $personalData
         ->add('user.json', ['name' => $this->name, 'email' => $this->email])
         ->addFile(storage_path("avatars/{$this->id}.jpg");


### PR DESCRIPTION
Fixes class name type hint in examples so they're all the same and use the correct class.