### PR TITLE
Remove duplicate variable assignment

### DIFF
--- a/src/Jobs/CreatePersonalDataExportJob.php
+++ b/src/Jobs/CreatePersonalDataExportJob.php
@@ -30,9 +30,7 @@ class CreatePersonalDataExportJob implements ShouldQueue
     {
         $temporaryDirectory = (new TemporaryDirectory())->create();
 
-        $personalDataSelection = (new PersonalDataSelection($temporaryDirectory))->forUser($this->user);
-
-        $this->user->selectPersonalData($personalDataSelection);
+        $personalDataSelection = $this->selectPersonalData($temporaryDirectory);
 
         event(new PersonalDataSelected($personalDataSelection, $this->user));
 
@@ -47,7 +45,7 @@ class CreatePersonalDataExportJob implements ShouldQueue
 
     protected function selectPersonalData(TemporaryDirectory $temporaryDirectory): PersonalDataSelection
     {
-        $personalData = new PersonalDataSelection($temporaryDirectory);
+        $personalData = (new PersonalDataSelection($temporaryDirectory))->forUser($this->user);
 
         $this->user->selectPersonalData($personalData);
 


### PR DESCRIPTION
Removes a statement where a variable gets assigned and immediately gets overwritten by a similar statement.