### PR TITLE
use signed URLs for download

### DIFF
--- a/resources/views/mail.blade.php
+++ b/resources/views/mail.blade.php
@@ -3,7 +3,7 @@
 
 You can now download a zip file containing all data we got for your account!
 
-@component('mail::button', ['url' => route('personal-data-exports', $zipFilename)])
+@component('mail::button', ['url' => \Illuminate\Support\Facades\URL::temporarySignedRoute('personal-data-exports', $deletionDatetime, ['zipFilename' => $zipFilename])])
 Download zip file
 @endcomponent
 

--- a/src/PersonalDataExportServiceProvider.php
+++ b/src/PersonalDataExportServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\PersonalDataExport;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Spatie\PersonalDataExport\Commands\CleanOldPersonalDataExportsCommand;
+use Spatie\PersonalDataExport\Http\Controllers\PersonalDataExportController;
 
 class PersonalDataExportServiceProvider extends ServiceProvider
 {
@@ -23,7 +24,8 @@ class PersonalDataExportServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'personal-data-export');
 
         Route::macro('personalDataExports', function (string $url) {
-            Route::get("$url/{zipFilename}", '\Spatie\PersonalDataExport\Http\Controllers\PersonalDataExportController@export')
+            Route::get("$url/{zipFilename}", '\\'.PersonalDataExportController::class.'@export')
+                ->middleware('signed')
                 ->name('personal-data-exports');
         });
 


### PR DESCRIPTION
fixes #40 

This change is breaking because all existing URLs will fail (signed middleware).
For me there's no time pressure because we've overridden the view and routes anyway - so it's fine for me to keep this open until a new major version is released.