### PR TITLE
Support PHP ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.0",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "ext-zip": "*",
         "illuminate/filesystem": "^8.0",


### PR DESCRIPTION
It would be great to keep 7.3 for now as it is still supported and this may break CIs.