### PR TITLE
Remove the deleted views from the service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,6 @@ return [
 
 ```
 
-Optionally, you can publish the view used by the mail with:
-
-```php
-php artisan vendor:publish --provider="Spatie\PersonalDataExport\PersonalDataExportServiceProvider" --tag="views"
-```
-
-This will create a file under `views/vendor/laravel-personal-data-export/mail.blade.php` that you can customize.
-
 ## Usage
 
 ### Selecting personal data
@@ -213,9 +205,7 @@ If you don't want to enforce that a user should be logged in to able to download
 
 ### Customizing the mail
 
-You can customize mail by [publishing the views](https://github.com/spatie/laravel-personal-data-export#installation) and editing `views/vendor/laravel-personal-data-export/mail.blade.php`
-
-You can also customize the mailable itself by creating your own mailable that extends `\Spatie\PersonalDataExport\Mail\PersonalDataExportCreatedMail` and register the class name of your mailable in the `mailable` config key of `config/personal-data-export.php`.
+You can customize the mailable itself by creating your own mailable that extends `\Spatie\PersonalDataExport\Mail\PersonalDataExportCreatedMail` and register the class name of your mailable in the `mailable` config key of `config/personal-data-export.php`.
 
 ### Customizing the queue
 

--- a/src/PersonalDataExportServiceProvider.php
+++ b/src/PersonalDataExportServiceProvider.php
@@ -14,13 +14,7 @@ class PersonalDataExportServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../config/personal-data-export.php' => config_path('personal-data-export.php'),
             ], 'config');
-
-            $this->publishes([
-                __DIR__.'/../resources/views' => base_path('resources/views/vendor/personal-data-export'),
-            ], 'views');
         }
-
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'personal-data-export');
 
         Route::macro('personalDataExports', function (string $url) {
             Route::get("$url/{zipFilename}", '\Spatie\PersonalDataExport\Http\Controllers\PersonalDataExportController@export')


### PR DESCRIPTION
This was giving some troubles when trying to publish the file or cache the views when deploying. `https://github.com/spatie/laravel-personal-data-export/blob/1.3.2/resources/views/mail.blade.php` was deleted in v2. The readme is also outdated.

Can you tag a release when you get this merged?

Thanks!