### PR TITLE
Add usable translations for the notification and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ public function selectPersonalData(PersonalDataSelection $personalData): void {
 
 `$personalData` is used to determine the content of the zip file that the user will be able to download. You can call these methods on it:
 
--   `add`: the first parameter is the name of the file in the inside the zip file. The second parameter is the content that should go in that file. If you pass an array here, we will encode it to JSON.
--   `addFile`: the first parameter is a path to a file which will be copied to the zip. You can also add a disk name as the second parameter.
+- `add`: the first parameter is the name of the file in the inside the zip file. The second parameter is the content that should go in that file. If you pass an array here, we will encode it to JSON.
+- `addFile`: the first parameter is a path to a file which will be copied to the zip. You can also add a disk name as the second parameter.
 
 The name of the export itself can be set using the `personalDataExportName` on the user. This will only affect the name of the download that will be sent as a response to the user, not the name of the zip stored on disk.
 
@@ -193,7 +193,7 @@ use Spatie\PersonalDataExport\Jobs\CreatePersonalDataExportJob;
 dispatch(new CreatePersonalDataExportJob(auth()->user()));
 ```
 
-By default, this job is queued. It will copy all files and content you selected in the `selectPersonalData` on your user to a temporary directory. Next, that temporary directory will be zipped and copied over to the `personal-data-exports` disk. A link to this zip will be mailed to the user.
+By default, this job is queued. It will copy all files and content you selected in the `selectPersonalData` on your user to a temporary directory. Next, that temporary directory will be zipped and copied over to the `personal-data-exports` disk. A link to this zip will be mailed to the user. 
 
 ### Securing the export
 
@@ -219,23 +219,18 @@ Here is an example:
 
 ```php
 use Spatie\PersonalDataExport\Notifications\PersonalDataExportedNotification as SpatiePersonalDataExportedNotification;
-
 class PersonalDataExportedNotification extends SpatiePersonalDataExportedNotification
 {
-
     public function via($notifiable)
     {
         return ['mail'];
     }
-
     public function toMail($notifiable)
     {
         $downloadUrl = route('personal-data-exports', $this->zipFilename);
-
         if (static::$toMailCallback) {
             return call_user_func(static::$toMailCallback, $notifiable, $downloadUrl);
         }
-
         return (new MailMessage)
             ->subject(trans('personal-data-exports.notifications.subject'))
             ->line(trans('personal-data-exports.notifications.instructions'))
@@ -276,23 +271,20 @@ dispatch(new MyCustomJobClass(auth()->user()));
 #### PersonalDataSelected
 
 This event will be fired after the personal data has been selected. It has two public properties:
-
--   `$personalData`: an instance of `PersonalData`. In your listeners you can call the `add`, `addFile` methods on this object to add extra content to the zip.
--   `$user`: the user for which this personal data has been selected.
+- `$personalData`: an instance of `PersonalData`. In your listeners you can call the `add`, `addFile` methods on this object to add extra content to the zip.
+- `$user`: the user for which this personal data has been selected.
 
 #### PersonalDataExportCreated
 
 This event will be fired after the personal data zip has been created. It has two public properties:
-
--   `$zipFilename`: the name of the zip filename.
--   `$user`: the user for which this zip has been created.
+- `$zipFilename`: the name of the zip filename.
+- `$user`: the user for which this zip has been created.
 
 #### PersonalDataExportDownloaded
 
 This event will be fired after the export has been download. It has two public properties:
-
--   `$zipFilename`: the name of the zip filename.
--   `$user`: the user for which this zip has been created.
+- `$zipFilename`: the name of the zip filename.
+- `$user`: the user for which this zip has been created.
 
 You could use this event to immediately clean up the downloaded zip.
 
@@ -300,7 +292,7 @@ You could use this event to immediately clean up the downloaded zip.
 
 You can run all tests by issuing this command:
 
-```bash
+``` bash
 composer test
 ```
 
@@ -318,8 +310,8 @@ If you discover any security related issues, please email freek@spatie.be instea
 
 ## Credits
 
--   [Freek Van der Herten](https://github.com/freekmurze)
--   [All Contributors](../../contributors)
+- [Freek Van der Herten](https://github.com/freekmurze)
+- [All Contributors](../../contributors)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ public function selectPersonalData(PersonalDataSelection $personalData): void {
 
 `$personalData` is used to determine the content of the zip file that the user will be able to download. You can call these methods on it:
 
-- `add`: the first parameter is the name of the file in the inside the zip file. The second parameter is the content that should go in that file. If you pass an array here, we will encode it to JSON.
-- `addFile`: the first parameter is a path to a file which will be copied to the zip. You can also add a disk name as the second parameter.
+-   `add`: the first parameter is the name of the file in the inside the zip file. The second parameter is the content that should go in that file. If you pass an array here, we will encode it to JSON.
+-   `addFile`: the first parameter is a path to a file which will be copied to the zip. You can also add a disk name as the second parameter.
 
 The name of the export itself can be set using the `personalDataExportName` on the user. This will only affect the name of the download that will be sent as a response to the user, not the name of the zip stored on disk.
 
@@ -193,7 +193,7 @@ use Spatie\PersonalDataExport\Jobs\CreatePersonalDataExportJob;
 dispatch(new CreatePersonalDataExportJob(auth()->user()));
 ```
 
-By default, this job is queued. It will copy all files and content you selected in the `selectPersonalData` on your user to a temporary directory. Next, that temporary directory will be zipped and copied over to the `personal-data-exports` disk. A link to this zip will be mailed to the user. 
+By default, this job is queued. It will copy all files and content you selected in the `selectPersonalData` on your user to a temporary directory. Next, that temporary directory will be zipped and copied over to the `personal-data-exports` disk. A link to this zip will be mailed to the user.
 
 ### Securing the export
 
@@ -203,9 +203,56 @@ When the user clicks the download link in the mail that gets sent after creating
 
 If you don't want to enforce that a user should be logged in to able to download a personal data export, you can set the `authentication_required` config value to `false`. Setting the value to `false` is less secure because anybody with a link to a zip file will be able to download it, but because the name of the zip file contains many random characters, it will be hard to guess it.
 
+### Translate the mail
+
+You need to publish the translations:
+
+```bash
+php artisan vendor:publish --provider="Spatie\PersonalDataExport\PersonalDataExportServiceProvider" --tag="translations"
+```
+
 ### Customizing the mail
 
-You can customize the mailable itself by creating your own mailable that extends `\Spatie\PersonalDataExport\Mail\PersonalDataExportCreatedMail` and register the class name of your mailable in the `mailable` config key of `config/personal-data-export.php`.
+You can customize the mailable itself by creating your own mailable that extends `Spatie\PersonalDataExport\Notifications\PersonalDataExportedNotification` and register the class name of your mailable in the `mailable` config key of `config/personal-data-export.php`.
+
+Here is an example:
+
+```php
+use Spatie\PersonalDataExport\Notifications\PersonalDataExportedNotification as SpatiePersonalDataExportedNotification;
+
+class PersonalDataExportedNotification extends SpatiePersonalDataExportedNotification
+{
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        $downloadUrl = route('personal-data-exports', $this->zipFilename);
+
+        if (static::$toMailCallback) {
+            return call_user_func(static::$toMailCallback, $notifiable, $downloadUrl);
+        }
+
+        return (new MailMessage)
+            ->subject(trans('personal-data-exports.notifications.subject'))
+            ->line(trans('personal-data-exports.notifications.instructions'))
+            ->action(trans('personal-data-exports.notifications.action'), $downloadUrl)
+            ->line(trans('personal-data-exports.notifications.deletion_message', ['date' => $this->deletionDatetime->format('Y-m-d H:i:s')]));
+    }
+}
+```
+
+Then register the class name of your mailable in the `mailable` config key of `config/personal-data-export.php`
+
+```php
+    /*
+     * Something like that
+     */
+    'notification' => \App\Notifications\PersonalDataExportedNotification::class,
+```
 
 ### Customizing the queue
 
@@ -229,20 +276,23 @@ dispatch(new MyCustomJobClass(auth()->user()));
 #### PersonalDataSelected
 
 This event will be fired after the personal data has been selected. It has two public properties:
-- `$personalData`: an instance of `PersonalData`. In your listeners you can call the `add`, `addFile` methods on this object to add extra content to the zip.
-- `$user`: the user for which this personal data has been selected.
+
+-   `$personalData`: an instance of `PersonalData`. In your listeners you can call the `add`, `addFile` methods on this object to add extra content to the zip.
+-   `$user`: the user for which this personal data has been selected.
 
 #### PersonalDataExportCreated
 
 This event will be fired after the personal data zip has been created. It has two public properties:
-- `$zipFilename`: the name of the zip filename.
-- `$user`: the user for which this zip has been created.
+
+-   `$zipFilename`: the name of the zip filename.
+-   `$user`: the user for which this zip has been created.
 
 #### PersonalDataExportDownloaded
 
 This event will be fired after the export has been download. It has two public properties:
-- `$zipFilename`: the name of the zip filename.
-- `$user`: the user for which this zip has been created.
+
+-   `$zipFilename`: the name of the zip filename.
+-   `$user`: the user for which this zip has been created.
 
 You could use this event to immediately clean up the downloaded zip.
 
@@ -250,7 +300,7 @@ You could use this event to immediately clean up the downloaded zip.
 
 You can run all tests by issuing this command:
 
-``` bash
+```bash
 composer test
 ```
 
@@ -268,8 +318,8 @@ If you discover any security related issues, please email freek@spatie.be instea
 
 ## Credits
 
-- [Freek Van der Herten](https://github.com/freekmurze)
-- [All Contributors](../../contributors)
+-   [Freek Van der Herten](https://github.com/freekmurze)
+-   [All Contributors](../../contributors)
 
 ## License
 

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'subject' => 'Personal Data Download',
+    'instructions' => 'Please click the button below to download a zip file containg all data we got for your account.',
+    'action' => 'Download Zip File',
+    'deletion_message' => 'This file will be deleted at :date.',
+];

--- a/src/Notifications/PersonalDataExportedNotification.php
+++ b/src/Notifications/PersonalDataExportedNotification.php
@@ -42,10 +42,13 @@ class PersonalDataExportedNotification extends Notification
         }
 
         return (new MailMessage)
-            ->subject(Lang::get('Personal Data Download'))
-            ->line(Lang::get('Please click the button below to download a zip file containg all data we got for your account.'))
-            ->action(Lang::get('Download Zip File'), $downloadUrl)
-            ->line(Lang::get('This file will be deleted at ' . $this->deletionDatetime->format('Y-m-d H:i:s') . '.'));
+            ->subject(trans('personal-data-export::notifications.subject'))
+            ->line(trans('personal-data-export::notifications.instructions'))
+            ->action(trans('personal-data-export::notifications.action'), $downloadUrl)
+            ->line(trans(
+                'personal-data-export::notifications.deletion_message',
+                ['date' => $this->deletionDatetime->format('Y-m-d H:i:s')]
+            ));
     }
 
     public static function toMailUsing($callback)

--- a/src/PersonalDataExportServiceProvider.php
+++ b/src/PersonalDataExportServiceProvider.php
@@ -12,7 +12,7 @@ class PersonalDataExportServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/personal-data-export.php' => config_path('personal-data-export.php'),
+                __DIR__ . '/../config/personal-data-export.php' => config_path('personal-data-export.php'),
             ], 'config');
         }
 
@@ -21,6 +21,15 @@ class PersonalDataExportServiceProvider extends ServiceProvider
                 ->name('personal-data-exports');
         });
 
+        $this->loadTranslationsFrom(
+            __DIR__ . '/../resources/lang/',
+            "personal-data-export"
+        );
+
+        $this->publishes([
+            __DIR__ . '/../resources/lang' => resource_path("lang/vendor/personal-data-export"),
+        ], "translations");
+
         $this->commands([
             CleanOldPersonalDataExportsCommand::class,
         ]);
@@ -28,6 +37,6 @@ class PersonalDataExportServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/personal-data-export.php', 'personal-data-export');
+        $this->mergeConfigFrom(__DIR__ . '/../config/personal-data-export.php', 'personal-data-export');
     }
 }


### PR DESCRIPTION
This pull request define a better translation logic: do not use Json anymore, use a date parameter and allow to publish translation file. #63 #64 