### PR TITLE
fix missing contents in zip folder

### DIFF
--- a/src/Zip.php
+++ b/src/Zip.php
@@ -67,9 +67,8 @@ class Zip
     {
         foreach ($files as $file) {
             if (file_exists($file)) {
-                $nameInZip = Str::after($file, $rootPath.'/');
-
-                $this->zipFile->addFile($file, ltrim($nameInZip, DIRECTORY_SEPARATOR));
+                // $nameInZip = Str::after($file, $rootPath.'/');
+                $this->zipFile->addFile($file, basename($file));
             }
             $this->fileCount++;
         }


### PR DESCRIPTION
I was trying to use this package in a project and I ran into some issues ,one of which is that it was creating the zip folder and generating the link as it should but I noticed the contents are not been copied into the zip folder so I took a closer look at the the package and I was able to figure out that while trying to add the files to the folder the package uses  $this->zipFile->addFile($file, ltrim($nameInZip, DIRECTORY_SEPARATOR));  but apparently 'DIRECTORY_SEPARATOR' isn't working as it should so I change the line  to $this->zipFile->addFile($file,basename($nameInZip));  in the Zip.php file in the Src folder and after that the package worked as it should and the folder contents were added properly.

I have other observations which I will also be working on and after this have been resolve will publish the changes 