### PR TITLE
Add option to ignore storage folder structrue in added files

### DIFF
--- a/config/personal-data-export.php
+++ b/config/personal-data-export.php
@@ -7,6 +7,11 @@ return [
     'disk' => 'personal-data-exports',
 
     /*
+     * If you want to keep the original directory structure for added files,
+     */
+    'keep_directory_structure' => true,
+
+    /*
      * The amount of days the exports will be available.
      */
     'delete_after_days' => 5,

--- a/src/PersonalDataSelection.php
+++ b/src/PersonalDataSelection.php
@@ -59,9 +59,7 @@ class PersonalDataSelection
     {
         $directory = trim($directory, '/');
 
-        $fileName = (is_null($directory) ? '' : $directory . '/') . pathinfo($pathToFile, PATHINFO_BASENAME);
-
-        $destination = $this->temporaryDirectory->path($fileName);
+        $destination = $this->getDestinationFilePath(pathinfo($pathToFile, PATHINFO_BASENAME), $directory);
 
         $this->ensureDoesNotOverwriteExistingFile($destination);
 
@@ -80,7 +78,7 @@ class PersonalDataSelection
 
         $pathOnDirectory = (is_null($directory) ? '' : $directory . '/') . $pathOnDisk;
 
-        $pathInTemporaryDirectory = $this->temporaryDirectory->path($pathOnDirectory);
+        $pathInTemporaryDirectory = $this->getDestinationFilePath($pathOnDisk, $directory);
 
         $this->ensureDoesNotOverwriteExistingFile($pathInTemporaryDirectory);
 
@@ -89,6 +87,17 @@ class PersonalDataSelection
         $this->files[] = $pathInTemporaryDirectory;
 
         return $this;
+    }
+
+    protected function getDestinationFilePath($pathOnDisk, $directory)
+    {
+        $directory = (is_null($directory) ? '' : $directory . '/');
+
+        return config('personal-data-export.keep_directory_structure')
+            ? $this->temporaryDirectory->path($directory . $pathOnDisk)
+            : $this->temporaryDirectory->path(
+                $directory.array_slice(explode('/', $pathOnDisk), -1)[0]
+            );
     }
 
     protected function ensureDoesNotOverwriteExistingFile(string $path)

--- a/tests/Tests/PersonalDataSelectionTest.php
+++ b/tests/Tests/PersonalDataSelectionTest.php
@@ -96,4 +96,40 @@ class PersonalDataSelectionTest extends TestCase
 
         $this->personalDataSelection->add('test.txt', 'test content');
     }
+
+
+    /** @test */
+    public function it_will_keep_directory_structure()
+    {
+
+        config(['personal-data-export.keep_directory_structure' => true]);
+
+
+        $directory = 'test-directory/';
+        $filePath = 'subdir/my-file.txt';
+
+        $disk = Storage::fake('test-disk');
+        $disk->put($filePath, 'my content');
+
+        $this->personalDataSelection->addFile($filePath, 'test-disk', $directory);
+        $this->assertFileContents($this->temporaryDirectory->path($directory . $filePath), 'my content');
+    }
+
+
+    /** @test */
+    public function it_will_not_keep_directory_structure()
+    {
+        config(['personal-data-export.keep_directory_structure' => false]);
+
+        $directory = 'test-directory/';
+        $filePath = 'subdir/my-file.txt';
+
+        $disk = Storage::fake('test-disk');
+        $disk->put($filePath, 'my content3');
+
+        $this->personalDataSelection->addFile($filePath, 'test-disk', $directory);
+        $this->assertFileContents($this->temporaryDirectory->path($directory . 'my-file.txt'), 'my content3');
+    }
+
+
 }

--- a/tests/Tests/PersonalDataSelectionTest.php
+++ b/tests/Tests/PersonalDataSelectionTest.php
@@ -101,9 +101,7 @@ class PersonalDataSelectionTest extends TestCase
     /** @test */
     public function it_will_keep_directory_structure()
     {
-
         config(['personal-data-export.keep_directory_structure' => true]);
-
 
         $directory = 'test-directory/';
         $filePath = 'subdir/my-file.txt';


### PR DESCRIPTION
When you add a file the directory structure of that file is kept in the resulting zip file. 

For example if I want to add a file with the path `path/to/my/file.png` and I add it with `$personalData->addFile('path/to/my/file.png', 'disk_name', 'images');`, the file be saved in this location: `temp-dir/images/path/to/my/file.png`.
I want the file to end up in `temp-dir/images/file.png` and not reveal my directory structure in the export file.

Adding `'keep_directory_structure' => false,` to the config file will add this behavior. Leaving it as true(the default) will keep the old behavior.