### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0]
+                php: [8.2, 8.0]
                 laravel: [9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -31,7 +31,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -   name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/filesystem": "^9.0",
         "illuminate/queue": "^9.0",
         "illuminate/support": "^9.0",
-        "nesbot/carbon": "^2.14",
+        "nesbot/carbon": "^2.63",
         "spatie/laravel-package-tools": "^1.9",
         "spatie/temporary-directory": "^2.0"
     },


### PR DESCRIPTION
## Summary

This PR adds PHP 8.2 to the tests workflow.

It also bumps the required minimum version for nesbot/carbon.

_id:php82-support/v1.0_