### PR TITLE
Make zipFilename and user properties public

### DIFF
--- a/src/Events/PersonalDataExportDownloaded.php
+++ b/src/Events/PersonalDataExportDownloaded.php
@@ -7,8 +7,8 @@ use Spatie\PersonalDataExport\ExportsPersonalData;
 class PersonalDataExportDownloaded
 {
     public function __construct(
-        string $zipFilename,
-        ?ExportsPersonalData $user
+        public string $zipFilename,
+        public ?ExportsPersonalData $user
     ) {
     }
 }


### PR DESCRIPTION
The zipFilename and user properties were changed from private to public to ensure accessibility, since in the dispatched event, accessing those properties is not possible, although its stated in the readme that they should. https://github.com/spatie/laravel-personal-data-export#personaldataexportdownloaded